### PR TITLE
Migrate to "TYPO3" guard constant

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die();
+defined('TYPO3') or die();
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addService(
     'svconnector_xls',


### PR DESCRIPTION
See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html