### PR TITLE
[BUGFIX] Prevent undefined array keys with PHP 8

### DIFF
--- a/Classes/Service/AbstractConnector.php
+++ b/Classes/Service/AbstractConnector.php
@@ -70,7 +70,7 @@ abstract class AbstractConnector extends ConnectorBase
         $this->logger->info('Structured data', $data);
 
         // Implement post-processing hook
-        if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][$this->extensionKey]['processArray'])) {
+        if (is_array(($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][$this->extensionKey]['processArray'] ?? ''))) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][$this->extensionKey]['processArray'] as $className) {
                 $processor = GeneralUtility::makeInstance($className);
                 $data = $processor->processArray($data, $this);

--- a/Classes/Service/XlsxConnector.php
+++ b/Classes/Service/XlsxConnector.php
@@ -57,7 +57,7 @@ final class XlsxConnector extends AbstractConnector
         }
 
         // Process the result if any hook is registered
-        if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][$this->extensionKey]['processResponse'])) {
+        if (is_array(($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][($this->extensionKey)]['processResponse'] ?? ''))) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][$this->extensionKey]['processResponse'] as $className) {
                 $processor = GeneralUtility::makeInstance($className);
                 $data = $processor->processResponse($data, $this);


### PR DESCRIPTION
With this, the import is running under TYPO3 v11 and PHP 8.1 without it was not.