### PR TITLE
Skip XSD validation in XML lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,6 @@
             "@php:unit:test",
             "@php:functional:test"
         ],
-        "xml:lint": "xmllint --pattern '*.xml,*.xlf,*.svg' --exclude bin,vendor,web --ansi ."
+        "xml:lint": "xmllint --pattern '*.xml,*.xlf,*.svg' --exclude bin,vendor,web --skip-xsd --ansi ."
     }
 }


### PR DESCRIPTION
We don't care about this in particular and in case an XSD schema is located remotely and the server is down, XML linting will fail.

See https://github.com/pagemachine/svconnector_xls/actions/runs/10157871703/job/28088788536