### PR TITLE
Remove pointless return after ConnectorBase::raiseError()

### DIFF
--- a/Classes/Service/XlsConnector.php
+++ b/Classes/Service/XlsConnector.php
@@ -52,20 +52,17 @@ final class XlsConnector extends AbstractConnector
 
         if ($filename === false) {
             $this->raiseError($fileUtility->getError(), 1605278290, $parameters, SourceErrorException::class);
-
-            return;
         }
 
         $reader = IOFactory::createReader('Xls');
         $reader->setReadDataOnly(true);
         $spreadsheet = $reader->load($filename);
+        $worksheet = null;
 
         try {
             $worksheet = $spreadsheet->getActiveSheet();
         } catch (SpreadsheetException $e) {
             $this->raiseError($e->getMessage(), 1596554370, $parameters, SourceErrorException::class);
-
-            return;
         }
 
         $data = [];

--- a/Classes/Service/XlsxConnector.php
+++ b/Classes/Service/XlsxConnector.php
@@ -41,6 +41,7 @@ final class XlsxConnector extends AbstractConnector
 
     /**
      * @return mixed
+     * @throws SourceErrorException
      */
     protected function query(array $parameters = [])
     {
@@ -52,20 +53,17 @@ final class XlsxConnector extends AbstractConnector
 
         if ($filename === false) {
             $this->raiseError($fileUtility->getError(), 1605278290, $parameters, SourceErrorException::class);
-
-            return;
         }
 
         $reader = IOFactory::createReader('Xlsx');
         $reader->setReadDataOnly(true);
         $spreadsheet = $reader->load($filename);
+        $worksheet = null;
 
         try {
             $worksheet = $spreadsheet->getActiveSheet();
         } catch (SpreadsheetException $e) {
             $this->raiseError($e->getMessage(), 1596554370, $parameters, SourceErrorException::class);
-
-            return;
         }
 
         $data = [];


### PR DESCRIPTION
Said API method already throws an exception, so a subsequent "return" will never be reached.